### PR TITLE
Bump to send-webmention 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "follow-redirects": "^1.2.5",
     "lodash": "^4.17.4",
     "microformat-node": "^2.0.1",
-    "send-webmention": "^1.0.0",
+    "send-webmention": "^1.0.1",
     "slash-escape": "^1.0.0",
     "url-toolkit": "^2.1.2",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Notably this squashes NodeSecurity warnings due to an accidental production dependency on `coveralls`.